### PR TITLE
La url de Atenea Cloud está implícita

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId 'com.ateneacloud.drive'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 140
-        versionName "2.3.5"
+        versionCode 141
+        versionName "2.3.5m1"
         multiDexEnabled true
         resValue "string", "authorities", applicationId + '.cameraupload.provider'
         resValue "string", "account_type", "com.seafile.seadroid2.account.api2"

--- a/app/src/main/java/com/ateneacloud/drive/account/ui/AccountDetailActivity.java
+++ b/app/src/main/java/com/ateneacloud/drive/account/ui/AccountDetailActivity.java
@@ -98,7 +98,6 @@ public class AccountDetailActivity extends BaseActivity implements  Toolbar.OnMe
         mServerEt = (EditText) findViewById(R.id.server_url);
         mEmailEt = (EmailAutoCompleteTextView) findViewById(R.id.email_address);
         mPasswdEt = (EditText) findViewById(R.id.password);
-        mSeaHubUrlHintTv = (TextView) findViewById(R.id.seahub_url_hint);
 
         mClearEmailIv = (ImageView) findViewById(R.id.iv_delete_email);
         mClearPasswordIv = (ImageView) findViewById(R.id.iv_delete_pwd);

--- a/app/src/main/java/com/ateneacloud/drive/account/ui/SeafileAuthenticatorActivity.java
+++ b/app/src/main/java/com/ateneacloud/drive/account/ui/SeafileAuthenticatorActivity.java
@@ -81,9 +81,7 @@ public class SeafileAuthenticatorActivity extends BaseAuthenticatorActivity {
                         startActivityForResult(intent, SeafileAuthenticatorActivity.REQ_SIGNUP);
                         break;
                     case OTHER_SERVER:
-                        intent = new Intent(SeafileAuthenticatorActivity.this, AccountDetailActivity.class);
-                        intent.putExtras(getIntent());
-                        startActivityForResult(intent, SeafileAuthenticatorActivity.REQ_SIGNUP);
+                        launchAccountDetailActivity();
                         break;
                     default:
                         return;
@@ -115,6 +113,10 @@ public class SeafileAuthenticatorActivity extends BaseAuthenticatorActivity {
                 navigateUpOrBack(SeafileAuthenticatorActivity.this, null);
             }
         });
+
+        // When this activity starts, always start Detail Ativity
+        // This is because Atenea Cloud only supports that type of login
+        launchAccountDetailActivity();
     }
 
     @Override
@@ -197,5 +199,12 @@ public class SeafileAuthenticatorActivity extends BaseAuthenticatorActivity {
         setAccountAuthenticatorResult(result);
         setResult(RESULT_OK, intent);
         finish();
+    }
+
+    private void launchAccountDetailActivity() {
+        Intent intent = new Intent(SeafileAuthenticatorActivity.this, AccountDetailActivity.class);
+        intent.putExtra(SeafileAuthenticatorActivity.ARG_SERVER_URI, getString(R.string.server_atenea_cloud));
+        intent.putExtras(getIntent());
+        startActivityForResult(intent, SeafileAuthenticatorActivity.REQ_SIGNUP);
     }
 }

--- a/app/src/main/res/layout/account_detail.xml
+++ b/app/src/main/res/layout/account_detail.xml
@@ -1,20 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:orientation="vertical">
 
     <include layout="@layout/toolbar_actionbar" /> <!-- placeholder, empty except on L -->
-    <CheckBox
-        android:id="@+id/https_checkbox"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/cb_padding_left"
-        android:layout_marginLeft="@dimen/cb_padding_left"
-        android:layout_marginTop="@dimen/cb_padding_top"
-        android:onClick="onHttpsCheckboxClicked"
-        android:text="@string/accounts_https_hint"
-        android:textSize="@dimen/cb_btn_txt_size" />
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -30,16 +21,6 @@
             android:layout_height="wrap_content"
             android:hint="@string/server_hint">
 
-            <EditText
-                android:id="@+id/server_url"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="@dimen/et_margin_left"
-                android:layout_marginRight="@dimen/et_margin_right"
-                android:layout_marginBottom="@dimen/et_margin_bottom"
-                android:importantForAutofill="auto"
-                android:inputType="textUri"
-                android:textSize="@dimen/et_txt_size" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <RelativeLayout
@@ -181,13 +162,31 @@
         android:layout_marginRight="@dimen/tv_margin_right"
         android:text="" />
 
-    <TextView
-        android:id="@+id/seahub_url_hint"
+    <CheckBox
+        android:id="@+id/https_checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/cb_padding_left"
+        android:layout_marginLeft="@dimen/cb_padding_left"
+        android:layout_marginTop="@dimen/cb_padding_top"
+        android:checked="true"
+        android:onClick="onHttpsCheckboxClicked"
+        android:text="@string/accounts_https_hint"
+        android:textSize="@dimen/cb_btn_txt_size"
+        android:visibility="invisible"
+        tools:visibility="invisible" />
+
+    <EditText
+        android:id="@+id/server_url"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginLeft="@dimen/tv_margin_left"
-        android:layout_marginRight="@dimen/tv_margin_right"
-        android:text="@string/seahub_url_hint"
-        android:textSize="@dimen/tv_txt_size" />
+        android:layout_marginLeft="@dimen/et_margin_left"
+        android:layout_marginRight="@dimen/et_margin_right"
+        android:layout_marginBottom="@dimen/et_margin_bottom"
+        android:importantForAutofill="auto"
+        android:inputType="textUri"
+        android:textSize="@dimen/et_txt_size"
+        android:visibility="invisible"
+        tools:visibility="invisible" />
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,6 +151,7 @@
   </string-array>
   <string name="server_name_top" translatable="false">cloud.seafile.com</string>
   <string name="server_url_seacloud" translatable="false">https://cloud.seafile.com</string>
+  <string name="server_atenea_cloud" translatable="false">https://drive.ateneacloud.com</string>
   <string name="network_down">No network connection</string>
   <string name="unknow_error">Unknown error</string>
   <string name="invalid_server_address">Invalid server address</string>


### PR DESCRIPTION
Sólo se va a permitir un typo de cuenta, la detallada, que sería la opción que debería elegir un usuario. Lo he hecho modificando SeafileAuthenticatorActivity para que al cargar se seleccione automáticamente esa opción. Lo he hecho así porque aquí se ésta usando AccountManager de Android y creo que sería más lío tocar más cosas, además de que se podría llega a esta actividad desde más sitios y de esta forma se garantiza que solo haya una posibilidad de tipo de cuenta.

Por otro lado, he ocultado el input que pide la url y ésta llega como parámetro configurable en strings.xml